### PR TITLE
Register post types on load

### DIFF
--- a/inmovilla-properties.php
+++ b/inmovilla-properties.php
@@ -84,6 +84,7 @@ final class InmovillaProperties {
 
     public function on_plugins_loaded() {
         load_plugin_textdomain('inmovilla-properties', false, dirname(plugin_basename(INMOVILLA_PROPERTIES_PLUGIN_FILE)) . '/languages/');
+        $this->register_post_types_and_taxonomies();
         new Inmovilla_Properties_Manager();
         new InmovillaShortcodes();
         new InmovillaSEO();


### PR DESCRIPTION
## Summary
- Hook register_post_types_and_taxonomies during plugin load so custom post types register on every request
- confirm register_post_types_and_taxonomies is independent from activation

## Testing
- `php -l inmovilla-properties.php`


------
https://chatgpt.com/codex/tasks/task_e_68b40bce23a483309fbccdef238cafeb