### PR TITLE
refactor: replace deprecated plugin path constant

### DIFF
--- a/admin/admin-settings.php
+++ b/admin/admin-settings.php
@@ -151,14 +151,14 @@ class Inmovilla_Admin_Settings {
      */
     public function settings_page() {
         $this->options = get_option('inmovilla_properties_options');
-        include INMOVILLA_PLUGIN_PATH . 'admin/partials/settings-form.php';
+        include INMOVILLA_PROPERTIES_PLUGIN_DIR . 'admin/partials/settings-form.php';
     }
     
     /**
      * Página de dashboard
      */
     public function dashboard_page() {
-        include INMOVILLA_PLUGIN_PATH . 'admin/admin-dashboard.php';
+        include INMOVILLA_PROPERTIES_PLUGIN_DIR . 'admin/admin-dashboard.php';
     }
     
     /**

--- a/public/class-inmovilla-ajax.php
+++ b/public/class-inmovilla-ajax.php
@@ -58,7 +58,7 @@ class Inmovilla_Ajax {
             $html = '';
             foreach ($properties as $property) {
                 ob_start();
-                include INMOVILLA_PLUGIN_PATH . 'templates/property-card.php';
+                include INMOVILLA_PROPERTIES_PLUGIN_DIR . 'templates/property-card.php';
                 $html .= ob_get_clean();
             }
             
@@ -109,7 +109,7 @@ class Inmovilla_Ajax {
             $html = '';
             foreach ($properties as $property) {
                 ob_start();
-                include INMOVILLA_PLUGIN_PATH . 'templates/property-card.php';
+                include INMOVILLA_PROPERTIES_PLUGIN_DIR . 'templates/property-card.php';
                 $html .= ob_get_clean();
             }
             

--- a/templates/property-list.php
+++ b/templates/property-list.php
@@ -28,7 +28,7 @@ $secondary_color = get_option('inmovilla_secondary_color', '#0073aa');
 
                     $template = locate_template('inmovilla/property-card.php');
                     if (!$template) {
-                        $template = INMOVILLA_PLUGIN_PATH . 'templates/property-card.php';
+                        $template = INMOVILLA_PROPERTIES_PLUGIN_DIR . 'templates/property-card.php';
                     }
                     include $template;
                     ?>


### PR DESCRIPTION
## Summary
- replace `INMOVILLA_PLUGIN_PATH` with `INMOVILLA_PROPERTIES_PLUGIN_DIR`

## Testing
- `php -l templates/property-list.php && php -l public/class-inmovilla-ajax.php && php -l admin/admin-settings.php`
- `npm test` *(fails: package.json missing)*
- `composer test` *(fails: command not defined)*

------
https://chatgpt.com/codex/tasks/task_e_68b40bd19580833099e460efaf816e81