### PR TITLE
Add configurable sync interval

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,6 +68,10 @@ Propiedades destacadas.
 3. En WordPress: Ajustes → Inmovilla Properties
 4. Pegar el token y guardar
 
+## Sincronización
+
+El proceso de sincronización se ejecuta de forma periódica mediante WP-Cron. Cada ejecución procesa 20 propiedades; por ejemplo, seis ejecuciones consecutivas importarán unas 120 propiedades.
+
 ## URLs SEO
 
 El plugin genera URLs amigables automáticamente:

--- a/includes/class-inmovilla-admin.php
+++ b/includes/class-inmovilla-admin.php
@@ -79,14 +79,31 @@ class InmovillaAdmin {
                             <label for="properties_per_page"><?php _e('Propiedades por página', 'inmovilla-properties'); ?></label>
                         </th>
                         <td>
-                            <input 
-                                type="number" 
-                                id="properties_per_page" 
-                                name="inmovilla_properties_settings[properties_per_page]" 
-                                value="<?php echo esc_attr($settings['properties_per_page'] ?? 12); ?>" 
-                                min="1" 
+                            <input
+                                type="number"
+                                id="properties_per_page"
+                                name="inmovilla_properties_settings[properties_per_page]"
+                                value="<?php echo esc_attr($settings['properties_per_page'] ?? 12); ?>"
+                                min="1"
                                 max="50"
                             />
+                        </td>
+                    </tr>
+
+                    <tr>
+                        <th scope="row">
+                            <label for="schedule_interval"><?php _e('Intervalo de sincronización', 'inmovilla-properties'); ?></label>
+                        </th>
+                        <td>
+                            <select id="schedule_interval" name="inmovilla_properties_settings[schedule_interval]">
+                                <?php
+                                $schedules = wp_get_schedules();
+                                $current_interval = $settings['schedule_interval'] ?? 'hourly';
+                                foreach ($schedules as $key => $schedule) {
+                                    echo '<option value="' . esc_attr($key) . '"' . selected($current_interval, $key, false) . '>' . esc_html($schedule['display']) . '</option>';
+                                }
+                                ?>
+                            </select>
                         </td>
                     </tr>
 

--- a/includes/class-inmovilla-properties-manager.php
+++ b/includes/class-inmovilla-properties-manager.php
@@ -18,7 +18,9 @@ class Inmovilla_Properties_Manager {
         add_action('inmovilla_sync_properties', array($this, 'sync_properties'));
 
         if (!wp_next_scheduled('inmovilla_sync_properties')) {
-            wp_schedule_event(time(), 'hourly', 'inmovilla_sync_properties');
+            $settings = get_option('inmovilla_properties_settings', array());
+            $interval = $settings['schedule_interval'] ?? 'hourly';
+            wp_schedule_event(time(), $interval, 'inmovilla_sync_properties');
         }
         
         // Ya no controlamos los templates desde aquí, lo hará Elementor o el tema.


### PR DESCRIPTION
## Summary
- allow admin to select cron interval for property sync
- use saved interval when scheduling sync event
- document sync frequency with example

## Testing
- `php -l includes/class-inmovilla-admin.php`
- `php -l includes/class-inmovilla-properties-manager.php`


------
https://chatgpt.com/codex/tasks/task_e_68b40bd9df848330a0a92b46ea0a7804