### PR TITLE
Add filter-controlled mock properties data

### DIFF
--- a/includes/class-inmovilla-api.php
+++ b/includes/class-inmovilla-api.php
@@ -24,12 +24,10 @@ class InmovillaAPI {
      */
     public function request($endpoint, $params = array()) {
         
-        // --- INICIO DE LA MODIFICACIÓN PARA PRUEBAS ---
-        // Si el modo debug de WordPress está activo y se piden propiedades, devuelve datos de prueba.
-        if (defined('WP_DEBUG') && WP_DEBUG === true && $endpoint === 'properties') {
-            return $this->get_mock_properties();
+        $mock = $this->get_mock_properties($endpoint);
+        if (false !== $mock) {
+            return $mock;
         }
-        // --- FIN DE LA MODIFICACIÓN ---
 
         if (empty($this->api_token)) {
             return new WP_Error('no_token', __('Token de API no configurado', 'inmovilla-properties'));
@@ -67,10 +65,25 @@ class InmovillaAPI {
     }
     
     /**
-     * Devuelve un array de propiedades de prueba para evaluar el diseño.
+     * Obtiene datos ficticios de propiedades si está habilitado.
+     *
+     * @param string $endpoint Endpoint solicitado.
+     * @return array|false
+     */
+    private function get_mock_properties($endpoint) {
+        if ($endpoint !== 'properties' || !apply_filters('inmovilla_mock_data', false)) {
+            return false;
+        }
+
+        return $this->mock_properties_data();
+    }
+
+    /**
+     * Datos ficticios de propiedades para evaluar el diseño.
+     *
      * @return array
      */
-    private function get_mock_properties() {
+    private function mock_properties_data() {
         return array(
             'data' => array(
                 array(
@@ -101,7 +114,7 @@ class InmovillaAPI {
                     'reference' => 'REF-002',
                     'type' => 'Chalet'
                 ),
-                 array(
+                array(
                     'id' => 3,
                     'title' => 'Ático con Vistas al Mar',
                     'price' => 620000,
@@ -119,7 +132,6 @@ class InmovillaAPI {
             'pagination' => '<a href="#">1</a><span class="current">2</span><a href="#">3</a>'
         );
     }
-
 
     /**
      * Obtener propiedades


### PR DESCRIPTION
## Summary
- Use `inmovilla_mock_data` filter to optionally return mock properties data
- Extract mock data into dedicated method

## Testing
- `php -l includes/class-inmovilla-api.php`


------
https://chatgpt.com/codex/tasks/task_e_68b40bdb08ec8330addf79540e33094f