### PR TITLE
Add AJAX hooks and security checks for favorites and search

### DIFF
--- a/includes/class-inmovilla-favorites.php
+++ b/includes/class-inmovilla-favorites.php
@@ -10,13 +10,21 @@ if (!defined('ABSPATH')) {
 class InmovillaFavorites {
 
     public function __construct() {
-        // Constructor básico
+        add_action('wp_ajax_inmovilla_toggle_favorite', array($this, 'handle_ajax_favorites'));
+        add_action('wp_ajax_nopriv_inmovilla_toggle_favorite', array($this, 'handle_ajax_favorites'));
     }
 
     /**
      * Manejar favoritos AJAX
      */
     public function handle_ajax_favorites() {
+        check_ajax_referer('inmovilla_public_nonce', 'nonce');
+
+        if (is_user_logged_in() && !current_user_can('read')) {
+            wp_send_json_error(array(
+                'message' => __('Permisos insuficientes', 'inmovilla-properties'),
+            ));
+        }
 
         $property_id = sanitize_text_field($_POST['property_id'] ?? '');
         $action = sanitize_text_field($_POST['action_type'] ?? 'toggle');

--- a/includes/class-inmovilla-search.php
+++ b/includes/class-inmovilla-search.php
@@ -10,13 +10,21 @@ if (!defined('ABSPATH')) {
 class InmovillaSearch {
 
     public function __construct() {
-        // Constructor básico
+        add_action('wp_ajax_inmovilla_search', array($this, 'handle_ajax_search'));
+        add_action('wp_ajax_nopriv_inmovilla_search', array($this, 'handle_ajax_search'));
     }
 
     /**
      * Manejar búsqueda AJAX
      */
     public function handle_ajax_search() {
+        check_ajax_referer('inmovilla_public_nonce', 'nonce');
+
+        if (is_user_logged_in() && !current_user_can('read')) {
+            wp_send_json_error(array(
+                'message' => __('Permisos insuficientes', 'inmovilla-properties'),
+            ));
+        }
 
         $search_term = sanitize_text_field($_POST['search'] ?? '');
         $type = sanitize_text_field($_POST['type'] ?? '');


### PR DESCRIPTION
## Summary
- Register AJAX actions for toggling favorites and performing searches for both logged-in and guest users
- Add nonce and capability checks in favorites and search handlers

## Testing
- `php -l includes/class-inmovilla-favorites.php`
- `php -l includes/class-inmovilla-search.php`


------
https://chatgpt.com/codex/tasks/task_e_68b40eefd49083309d907c507d1aa76d