### PR TITLE
Read front-end colors from settings option

### DIFF
--- a/public/class-inmovilla-public.php
+++ b/public/class-inmovilla-public.php
@@ -65,9 +65,9 @@ class Inmovilla_Public {
      * Añadir estilos personalizados desde la configuración
      */
     public function add_custom_styles() {
-        $options = get_option('inmovilla_properties_options', array());
-        $primary_color = $options['primary_color'] ?? '#2563eb';
-        $secondary_color = $options['secondary_color'] ?? '#64748b';
+        $settings = get_option('inmovilla_properties_settings', array());
+        $primary_color = $settings['primary_color'] ?? '#2563eb';
+        $secondary_color = $settings['secondary_color'] ?? '#64748b';
         
         echo "<style type='text/css'>
             :root {


### PR DESCRIPTION
## Summary
- Load color settings from the `inmovilla_properties_settings` option on the public side
- Use `$settings` variable for retrieving primary and secondary colors

## Testing
- `php -l public/class-inmovilla-public.php`
- `php <<'PHP' ... PHP`

------
https://chatgpt.com/codex/tasks/task_e_68b40ef301448330b19952880d2c1193