### PR TITLE
Rename global init function with prefix

### DIFF
--- a/inmovilla-properties.php
+++ b/inmovilla-properties.php
@@ -135,9 +135,11 @@ final class InmovillaProperties {
 /**
  * Función global para iniciar el plugin
  */
-function InmovillaProperties() {
-    return InmovillaProperties::instance();
+if (!function_exists('inmovilla_properties')) {
+    function inmovilla_properties() {
+        return InmovillaProperties::instance();
+    }
 }
 
 // Arrancamos el plugin
-InmovillaProperties();
+inmovilla_properties();


### PR DESCRIPTION
## Summary
- prevent duplicate declarations by renaming global init function to `inmovilla_properties`

## Testing
- `php -l inmovilla-properties.php`


------
https://chatgpt.com/codex/tasks/task_e_68b40ef5fb4083309828690a1488fa3e