### PR TITLE
Add media section and sharing actions to property pages

### DIFF
--- a/assets/js/inmovilla-public.js
+++ b/assets/js/inmovilla-public.js
@@ -60,6 +60,24 @@
             $(document).on('click', '.inmovilla-mobile-menu-toggle', function() {
                 $('.inmovilla-mobile-menu').slideToggle();
             });
+
+            // Botón imprimir
+            $(document).on('click', '.inmovilla-print-btn', function() {
+                var pdfUrl = $(this).data('pdf');
+                if (pdfUrl) {
+                    window.open(pdfUrl, '_blank');
+                } else {
+                    window.print();
+                }
+            });
+
+            // Botón enviar por email
+            $(document).on('click', '.inmovilla-send-btn', function() {
+                var subject = $(this).data('subject') || '';
+                var url = $(this).data('url') || window.location.href;
+                var mailto = 'mailto:?subject=' + encodeURIComponent(subject) + '&body=' + encodeURIComponent(url);
+                window.location.href = mailto;
+            });
         },
 
         // Inicializar galería de imágenes

--- a/includes/class-inmovilla-properties-manager.php
+++ b/includes/class-inmovilla-properties-manager.php
@@ -105,6 +105,11 @@ class Inmovilla_Properties_Manager {
             update_post_meta($post_id, 'size', isset($data['size']) ? floatval($data['size']) : '');
             update_post_meta($post_id, 'featured', !empty($data['featured']) ? 1 : 0);
             update_post_meta($post_id, 'property_type', isset($data['type']) ? sanitize_text_field($data['type']) : '');
+
+            // Medios adicionales
+            update_post_meta($post_id, 'video_url', isset($data['video_url']) ? esc_url_raw($data['video_url']) : '');
+            update_post_meta($post_id, 'virtual_tour_url', isset($data['virtual_tour_url']) ? esc_url_raw($data['virtual_tour_url']) : '');
+            update_post_meta($post_id, 'property_pdf', isset($data['property_pdf']) ? esc_url_raw($data['property_pdf']) : '');
             
             // Guardamos la galería de imágenes (como un array)
             if (!empty($data['images'])) {

--- a/templates/property-single.php
+++ b/templates/property-single.php
@@ -86,18 +86,31 @@ get_header(); ?>
                         <?php endif; ?>
 
                         <div class="property-actions">
-                            <button class="inmovilla-btn inmovilla-btn-primary inmovilla-contact-btn" 
+                            <button class="inmovilla-btn inmovilla-btn-primary inmovilla-contact-btn"
                                     data-property-id="<?php echo esc_attr($property['id']); ?>">
                                 📞 <?php _e('Contactar', 'inmovilla-properties'); ?>
                             </button>
 
-                            <button class="inmovilla-btn inmovilla-btn-secondary inmovilla-favorite-btn" 
+                            <button class="inmovilla-btn inmovilla-btn-secondary inmovilla-favorite-btn"
                                     data-property-id="<?php echo esc_attr($property['id']); ?>">
                                 ♡ <?php _e('Favorito', 'inmovilla-properties'); ?>
                             </button>
 
                             <button class="inmovilla-btn inmovilla-btn-outline inmovilla-share-btn">
                                 🔗 <?php _e('Compartir', 'inmovilla-properties'); ?>
+                            </button>
+
+                            <?php if (!empty($property['property_pdf'])): ?>
+                                <button class="inmovilla-btn inmovilla-btn-outline inmovilla-print-btn"
+                                        data-pdf="<?php echo esc_url($property['property_pdf']); ?>">
+                                    🖨 <?php _e('Imprimir', 'inmovilla-properties'); ?>
+                                </button>
+                            <?php endif; ?>
+
+                            <button class="inmovilla-btn inmovilla-btn-outline inmovilla-send-btn"
+                                    data-subject="<?php echo esc_attr($property['title'] ?? __('Propiedad', 'inmovilla-properties')); ?>"
+                                    data-url="<?php echo esc_url($properties_manager->get_property_url($property)); ?>">
+                                ✉ <?php _e('Enviar', 'inmovilla-properties'); ?>
                             </button>
                         </div>
                     </div>
@@ -149,6 +162,25 @@ get_header(); ?>
                             <div class="description-content">
                                 <?php echo wp_kses_post($property['description']); ?>
                             </div>
+                        </div>
+                    <?php endif; ?>
+
+                    <?php
+                    $has_media = !empty($property['video_url']) || !empty($property['virtual_tour_url']) || !empty($property['property_pdf']);
+                    if ($has_media): ?>
+                        <div class="property-media">
+                            <h3><?php _e('Medios', 'inmovilla-properties'); ?></h3>
+                            <ul class="media-list">
+                                <?php if (!empty($property['video_url'])): ?>
+                                    <li><a href="<?php echo esc_url($property['video_url']); ?>" target="_blank" rel="noopener"><?php _e('Video', 'inmovilla-properties'); ?></a></li>
+                                <?php endif; ?>
+                                <?php if (!empty($property['virtual_tour_url'])): ?>
+                                    <li><a href="<?php echo esc_url($property['virtual_tour_url']); ?>" target="_blank" rel="noopener"><?php _e('Tour virtual', 'inmovilla-properties'); ?></a></li>
+                                <?php endif; ?>
+                                <?php if (!empty($property['property_pdf'])): ?>
+                                    <li><a href="<?php echo esc_url($property['property_pdf']); ?>" target="_blank" rel="noopener"><?php _e('PDF', 'inmovilla-properties'); ?></a></li>
+                                <?php endif; ?>
+                            </ul>
                         </div>
                     <?php endif; ?>
 


### PR DESCRIPTION
## Summary
- show optional video, virtual tour and PDF links in a new “Medios” section on single properties
- add print and send buttons to property actions with JS handlers
- save video, tour and PDF URLs during synchronization

## Testing
- `php -l templates/property-single.php`
- `php -l includes/class-inmovilla-properties-manager.php`
- `node --check assets/js/inmovilla-public.js`
- `npm test` *(fails: missing package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68b41481ffb88330acbe7b3ac3fcc161