### PR TITLE
Add contact form modal with AJAX on property pages

### DIFF
--- a/assets/css/inmovilla-public.css
+++ b/assets/css/inmovilla-public.css
@@ -481,3 +481,58 @@
 .feature-size .inmovilla-icon-size::before {
     content: '\f546'; /* Icono de regla */
 }
+
+/* Modal de contacto */
+.inmovilla-contact-modal {
+    position: fixed;
+    top: 0;
+    left: 0;
+    width: 100%;
+    height: 100%;
+    background: rgba(0,0,0,0.6);
+    display: none;
+    align-items: center;
+    justify-content: center;
+    z-index: 10000;
+}
+
+.inmovilla-contact-modal .inmovilla-modal-content {
+    background: #fff;
+    padding: 20px;
+    max-width: 500px;
+    width: 90%;
+    border-radius: var(--inmovilla-radius);
+    position: relative;
+    box-shadow: var(--inmovilla-shadow);
+}
+
+.inmovilla-contact-modal .inmovilla-modal-close {
+    position: absolute;
+    top: 10px;
+    right: 15px;
+    cursor: pointer;
+    font-size: 20px;
+}
+
+.inmovilla-contact-modal .form-group {
+    margin-bottom: 15px;
+}
+
+.inmovilla-contact-modal label {
+    display: block;
+    margin-bottom: 5px;
+}
+
+.inmovilla-contact-modal input[type="text"],
+.inmovilla-contact-modal input[type="email"],
+.inmovilla-contact-modal textarea {
+    width: 100%;
+    padding: 8px;
+    border: 1px solid var(--inmovilla-border);
+    border-radius: var(--inmovilla-radius);
+}
+
+.inmovilla-contact-modal textarea {
+    min-height: 100px;
+    resize: vertical;
+}

--- a/assets/js/inmovilla-public.js
+++ b/assets/js/inmovilla-public.js
@@ -60,6 +60,36 @@
             $(document).on('click', '.inmovilla-mobile-menu-toggle', function() {
                 $('.inmovilla-mobile-menu').slideToggle();
             });
+
+            // Abrir formulario de contacto
+            $(document).on('click', '.inmovilla-contact-btn', function(e) {
+                e.preventDefault();
+                var subject = $(this).data('subject') || '';
+                $('#inmovilla-contact-subject').val(subject);
+                $('#inmovilla-contact-modal').fadeIn();
+            });
+
+            // Cerrar formulario de contacto
+            $(document).on('click', '.inmovilla-modal-close', function() {
+                $('#inmovilla-contact-modal').fadeOut();
+            });
+
+            // Enviar formulario de contacto
+            $(document).on('submit', '#inmovilla-contact-form', function(e) {
+                e.preventDefault();
+                var $form = $(this);
+                var data = $form.serialize();
+                data += '&action=inmovilla_send_contact&nonce=' + InmovillaPublic.config.nonce;
+                $.post(InmovillaPublic.config.ajaxUrl, data, function(response) {
+                    if (response.success) {
+                        $form[0].reset();
+                        $('#inmovilla-contact-modal').fadeOut();
+                        InmovillaPublic.showNotification(response.data.message, 'success');
+                    } else {
+                        InmovillaPublic.showNotification(response.data.message, 'error');
+                    }
+                });
+            });
         },
 
         // Inicializar galería de imágenes

--- a/languages/inmovilla-properties-es_ES.po
+++ b/languages/inmovilla-properties-es_ES.po
@@ -59,3 +59,63 @@ msgstr "Ver detalles"
 #: templates/property-card.php:127
 msgid "Contactar"
 msgstr "Contactar"
+
+#: templates/property-single.php:97
+msgid "Hacer una oferta"
+msgstr "Hacer una oferta"
+
+#: templates/property-single.php:102
+msgid "Solicitar cita"
+msgstr "Solicitar cita"
+
+#: templates/property-single.php:107
+msgid "Solicitar llamada"
+msgstr "Solicitar llamada"
+
+#: templates/property-single.php:119
+msgid "Nombre"
+msgstr "Nombre"
+
+#: templates/property-single.php:124
+msgid "Email"
+msgstr "Email"
+
+#: templates/property-single.php:129
+msgid "Teléfono"
+msgstr "Teléfono"
+
+#: templates/property-single.php:134
+msgid "Mensaje"
+msgstr "Mensaje"
+
+#: templates/property-single.php:139
+msgid "¿Cómo nos has conocido?"
+msgstr "¿Cómo nos has conocido?"
+
+#: templates/property-single.php:144
+msgid "Acepto la política de privacidad"
+msgstr "Acepto la política de privacidad"
+
+#: templates/property-single.php:148
+msgid "Enviar"
+msgstr "Enviar"
+
+#: public/class-inmovilla-ajax.php:176
+msgid "Por favor completa todos los campos obligatorios."
+msgstr "Por favor completa todos los campos obligatorios."
+
+#: public/class-inmovilla-ajax.php:182
+msgid "Solicitud: %s"
+msgstr "Solicitud: %s"
+
+#: public/class-inmovilla-ajax.php:183
+msgid "Nombre: %1$s\nEmail: %2$s\nTeléfono: %3$s\nOrigen: %4$s\nID Propiedad: %5$d\nMensaje:\n%6$s"
+msgstr "Nombre: %1$s\nEmail: %2$s\nTeléfono: %3$s\nOrigen: %4$s\nID Propiedad: %5$d\nMensaje:\n%6$s"
+
+#: public/class-inmovilla-ajax.php:192
+msgid "Solicitud enviada correctamente."
+msgstr "Solicitud enviada correctamente."
+
+#: public/class-inmovilla-ajax.php:195
+msgid "Error al enviar la solicitud."
+msgstr "Error al enviar la solicitud."

--- a/templates/property-single.php
+++ b/templates/property-single.php
@@ -86,12 +86,25 @@ get_header(); ?>
                         <?php endif; ?>
 
                         <div class="property-actions">
-                            <button class="inmovilla-btn inmovilla-btn-primary inmovilla-contact-btn" 
-                                    data-property-id="<?php echo esc_attr($property['id']); ?>">
-                                📞 <?php _e('Contactar', 'inmovilla-properties'); ?>
+                            <button class="inmovilla-btn inmovilla-btn-primary inmovilla-contact-btn"
+                                    data-property-id="<?php echo esc_attr($property['id']); ?>"
+                                    data-subject="<?php esc_attr_e('Hacer una oferta', 'inmovilla-properties'); ?>">
+                                💰 <?php _e('Hacer una oferta', 'inmovilla-properties'); ?>
                             </button>
 
-                            <button class="inmovilla-btn inmovilla-btn-secondary inmovilla-favorite-btn" 
+                            <button class="inmovilla-btn inmovilla-btn-primary inmovilla-contact-btn"
+                                    data-property-id="<?php echo esc_attr($property['id']); ?>"
+                                    data-subject="<?php esc_attr_e('Solicitar cita', 'inmovilla-properties'); ?>">
+                                📅 <?php _e('Solicitar cita', 'inmovilla-properties'); ?>
+                            </button>
+
+                            <button class="inmovilla-btn inmovilla-btn-primary inmovilla-contact-btn"
+                                    data-property-id="<?php echo esc_attr($property['id']); ?>"
+                                    data-subject="<?php esc_attr_e('Solicitar llamada', 'inmovilla-properties'); ?>">
+                                📞 <?php _e('Solicitar llamada', 'inmovilla-properties'); ?>
+                            </button>
+
+                            <button class="inmovilla-btn inmovilla-btn-secondary inmovilla-favorite-btn"
                                     data-property-id="<?php echo esc_attr($property['id']); ?>">
                                 ♡ <?php _e('Favorito', 'inmovilla-properties'); ?>
                             </button>
@@ -170,6 +183,48 @@ get_header(); ?>
                 <?php echo do_shortcode('[inmovilla_properties limit="4" type="' . ($property['type'] ?? '') . '" location="' . ($property['location']['city'] ?? '') . '"]'); ?>
             </div>
         </div>
+    </div>
+</div>
+
+<!-- Modal de contacto -->
+<div id="inmovilla-contact-modal" class="inmovilla-contact-modal" style="display:none;">
+    <div class="inmovilla-modal-content">
+        <span class="inmovilla-modal-close">&times;</span>
+        <form id="inmovilla-contact-form">
+            <input type="hidden" name="property_id" value="<?php echo esc_attr($property['id']); ?>">
+            <input type="hidden" name="subject" id="inmovilla-contact-subject" value="">
+
+            <div class="form-group">
+                <label for="inmovilla-name"><?php _e('Nombre', 'inmovilla-properties'); ?></label>
+                <input type="text" id="inmovilla-name" name="name" required>
+            </div>
+
+            <div class="form-group">
+                <label for="inmovilla-email"><?php _e('Email', 'inmovilla-properties'); ?></label>
+                <input type="email" id="inmovilla-email" name="email" required>
+            </div>
+
+            <div class="form-group">
+                <label for="inmovilla-phone"><?php _e('Teléfono', 'inmovilla-properties'); ?></label>
+                <input type="text" id="inmovilla-phone" name="phone">
+            </div>
+
+            <div class="form-group">
+                <label for="inmovilla-message"><?php _e('Mensaje', 'inmovilla-properties'); ?></label>
+                <textarea id="inmovilla-message" name="message" required></textarea>
+            </div>
+
+            <div class="form-group">
+                <label for="inmovilla-source"><?php _e('¿Cómo nos has conocido?', 'inmovilla-properties'); ?></label>
+                <input type="text" id="inmovilla-source" name="source">
+            </div>
+
+            <div class="form-group">
+                <label><input type="checkbox" name="privacy" required> <?php _e('Acepto la política de privacidad', 'inmovilla-properties'); ?></label>
+            </div>
+
+            <button type="submit" class="inmovilla-btn inmovilla-btn-primary"><?php _e('Enviar', 'inmovilla-properties'); ?></button>
+        </form>
     </div>
 </div>
 


### PR DESCRIPTION
## Summary
- add "Hacer una oferta", "Solicitar cita" and "Solicitar llamada" buttons on property detail pages
- implement modal contact form with privacy checkbox and optional source field
- handle form submissions via new AJAX endpoint and send email to site admin

## Testing
- `php -l templates/property-single.php`
- `php -l public/class-inmovilla-ajax.php`
- `msgfmt -c -o /dev/null languages/inmovilla-properties-es_ES.po`


------
https://chatgpt.com/codex/tasks/task_e_68b41483e2ec83308679a7aaecc5b22b