### PR TITLE
Add agency contact and legal note to property pages

### DIFF
--- a/assets/css/inmovilla-public.css
+++ b/assets/css/inmovilla-public.css
@@ -335,6 +335,20 @@
     margin-top: 5px;
 }
 
+/* Información adicional de la propiedad */
+.property-extra-info {
+    margin-top: 40px;
+    padding-top: 20px;
+    border-top: 1px solid var(--inmovilla-border);
+    font-size: 14px;
+    color: #666;
+}
+
+.property-extra-info .agency-contact,
+.property-extra-info .legal-note {
+    margin-bottom: 15px;
+}
+
 /* ===================================
    PAGINACIÓN
 =================================== */

--- a/includes/class-inmovilla-admin.php
+++ b/includes/class-inmovilla-admin.php
@@ -112,13 +112,47 @@ class InmovillaAdmin {
                             <label for="primary_color"><?php _e('Color primario', 'inmovilla-properties'); ?></label>
                         </th>
                         <td>
-                            <input 
-                                type="text" 
-                                id="primary_color" 
-                                name="inmovilla_properties_settings[primary_color]" 
-                                value="<?php echo esc_attr($settings['primary_color'] ?? '#2196F3'); ?>" 
+                            <input
+                                type="text"
+                                id="primary_color"
+                                name="inmovilla_properties_settings[primary_color]"
+                                value="<?php echo esc_attr($settings['primary_color'] ?? '#2196F3'); ?>"
                                 class="color-picker"
                             />
+                        </td>
+                    </tr>
+
+                    <tr>
+                        <th scope="row">
+                            <label for="agency_contact"><?php _e('Contacto de la agencia', 'inmovilla-properties'); ?></label>
+                        </th>
+                        <td>
+                            <textarea
+                                id="agency_contact"
+                                name="inmovilla_properties_settings[agency_contact]"
+                                rows="3"
+                                class="large-text"
+                            ><?php echo esc_textarea($settings['agency_contact'] ?? ''); ?></textarea>
+                            <p class="description">
+                                <?php _e('Información de contacto que se mostrará en la ficha de propiedad.', 'inmovilla-properties'); ?>
+                            </p>
+                        </td>
+                    </tr>
+
+                    <tr>
+                        <th scope="row">
+                            <label for="legal_note"><?php _e('Nota legal', 'inmovilla-properties'); ?></label>
+                        </th>
+                        <td>
+                            <textarea
+                                id="legal_note"
+                                name="inmovilla_properties_settings[legal_note]"
+                                rows="3"
+                                class="large-text"
+                            ><?php echo esc_textarea($settings['legal_note'] ?? ''); ?></textarea>
+                            <p class="description">
+                                <?php _e('Texto legal que aparecerá al final de la ficha de propiedad.', 'inmovilla-properties'); ?>
+                            </p>
                         </td>
                     </tr>
                 </table>

--- a/templates/property-single.php
+++ b/templates/property-single.php
@@ -169,6 +169,25 @@ get_header(); ?>
                 <h3><?php _e('Propiedades similares', 'inmovilla-properties'); ?></h3>
                 <?php echo do_shortcode('[inmovilla_properties limit="4" type="' . ($property['type'] ?? '') . '" location="' . ($property['location']['city'] ?? '') . '"]'); ?>
             </div>
+
+            <?php
+            $agency_contact = inmovilla_get_setting('agency_contact');
+            $legal_note = inmovilla_get_setting('legal_note');
+            if ($agency_contact || $legal_note): ?>
+                <div class="property-extra-info">
+                    <?php if ($agency_contact): ?>
+                        <div class="agency-contact">
+                            <?php echo wp_kses_post($agency_contact); ?>
+                        </div>
+                    <?php endif; ?>
+
+                    <?php if ($legal_note): ?>
+                        <div class="legal-note">
+                            <?php echo wp_kses_post($legal_note); ?>
+                        </div>
+                    <?php endif; ?>
+                </div>
+            <?php endif; ?>
         </div>
     </div>
 </div>


### PR DESCRIPTION
## Summary
- allow admins to configure agency contact and legal note fields
- render agency contact and legal note on property page footer
- style property footer info section

## Testing
- `php -l includes/class-inmovilla-admin.php`
- `php -l templates/property-single.php`


------
https://chatgpt.com/codex/tasks/task_e_68b4148b8d4083309df97666351702e2